### PR TITLE
Fix per phase active import export && added status LED

### DIFF
--- a/Kamstrup_mqtt_simple/Kamstrup_mqtt_simple.ino
+++ b/Kamstrup_mqtt_simple/Kamstrup_mqtt_simple.ino
@@ -26,7 +26,7 @@ void setup() {
   //DEBUG_PRINTLN("")
   Serial.begin(115200);
   Serial.println(" I can print something");
-
+  pinMode(BUILTIN_LED, OUTPUT);
   
 
   WiFi.begin(ssid, password);
@@ -60,7 +60,7 @@ void setup() {
   hexStr2bArr(encryption_key, conf_key, sizeof(encryption_key));
   hexStr2bArr(authentication_key, conf_authkey, sizeof(authentication_key));
   Serial.println("Setup completed");
-
+  digitalWrite(BUILTIN_LED, HIGH);
 }
 
 void loop() {
@@ -230,9 +230,11 @@ void hexStr2bArr(uint8_t* dest, const char* source, int bytes_n)
 
 void sendmsg(String topic, String payload) {
   if (client.connected() && WiFi.status() == WL_CONNECTED) {
+    digitalWrite(BUILTIN_LED, LOW);
     // If we are connected to WiFi and MQTT, send. (From Niels Ørbæk)
     client.publish(topic.c_str(), payload.c_str());
     delay(10);
+    digitalWrite(BUILTIN_LED, HIGH);
   } else {
     // Otherwise, restart the chip, hoping that the issue resolved itself.
     delay(60*1000);

--- a/Kamstrup_mqtt_simple/Kamstrup_mqtt_simple.ino
+++ b/Kamstrup_mqtt_simple/Kamstrup_mqtt_simple.ino
@@ -18,6 +18,11 @@ VectorView decryptedFrame(decryptedFrameBuffer, 0);
 MbusStreamParser streamParser(receiveBuffer, sizeof(receiveBuffer));
 mbedtls_gcm_context m_ctx;
 
+// wifi auto reconnect
+unsigned long currentMillis;
+unsigned long previousMillis;
+unsigned long wifiReconnectInterval = 30000;
+
 WiFiClient espClient;
 PubSubClient client(espClient);
 
@@ -81,7 +86,22 @@ void loop() {
       }
     }
   }
+
+  reconnectWifi();
+
   client.loop();
+}
+
+void reconnectWifi() {
+  currentMillis = millis();
+  // if WiFi is down, try reconnecting
+  if ((WiFi.status() != WL_CONNECTED) && (currentMillis - previousMillis >= wifiReconnectInterval)) {
+    Serial.print(millis());
+    Serial.println("Reconnecting to WiFi...");
+    WiFi.disconnect();
+    WiFi.reconnect();
+    previousMillis = currentMillis;
+  }
 }
 
 

--- a/Kamstrup_mqtt_simple/mbusparser.cpp
+++ b/Kamstrup_mqtt_simple/mbusparser.cpp
@@ -167,12 +167,12 @@ MeterData parseMbusFrame(const VectorView& frame)
       result.powerFactorL2 = getPower(frame, POWER_FACTOR_L2, result.powerFactorValidL2);
       result.powerFactorL3 = getPower(frame, POWER_FACTOR_L3, result.powerFactorValidL3);
       result.powerFactorTotal = getPower(frame, POWER_FACTOR, result.powerFactorTotalValid);
-      result.activeImportWhL1 = getPower(frame, ACTIVE_IMPORT_L1, result.activeImportWhValidL1);
-      result.activeImportWhL2 = getPower(frame, ACTIVE_IMPORT_L2, result.activeImportWhValidL2);
-      result.activeImportWhL3 = getPower(frame, ACTIVE_IMPORT_L3, result.activeImportWhValidL3);
-      result.activeExportWhL1 = getPower(frame, ACTIVE_EXPORT_L1, result.activeExportWhValidL1);
-      result.activeExportWhL2 = getPower(frame, ACTIVE_EXPORT_L2, result.activeExportWhValidL2);
-      result.activeExportWhL3 = getPower(frame, ACTIVE_EXPORT_L3, result.activeExportWhValidL3);
+      result.activeImportWhL1 = getPower(frame, ACTIVE_IMPORT_L1, result.activeImportWhValidL1)*10;
+      result.activeImportWhL2 = getPower(frame, ACTIVE_IMPORT_L2, result.activeImportWhValidL2)*10;
+      result.activeImportWhL3 = getPower(frame, ACTIVE_IMPORT_L3, result.activeImportWhValidL3)*10;
+      result.activeExportWhL1 = getPower(frame, ACTIVE_EXPORT_L1, result.activeExportWhValidL1)*10;
+      result.activeExportWhL2 = getPower(frame, ACTIVE_EXPORT_L2, result.activeExportWhValidL2)*10;
+      result.activeExportWhL3 = getPower(frame, ACTIVE_EXPORT_L3, result.activeExportWhValidL3)*10;
     }
   }
   return result;


### PR DESCRIPTION
Hi

It seems like the active import and active export of the individual phases also needs the *10, otherwise the resulting mqtt values are a factor 10 too small.

I also added a status indication using the LED build into the esp8266, such that it will turn on during the boot process, turn off when the esp has booted successfully and will blink whenever data is sent to the mqtt server.